### PR TITLE
relax telemetry dependency version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.1.2] - 2022-11-29
+### Changed
+* relaxed telemetry dependency
+
 ## [0.1.1] - 2022-10-06
 
 ### Changed

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule InfluxTelemetryReporter.MixProject do
   use Mix.Project
 
-  @version "0.1.1"
+  @version "0.1.2"
   @description "A generic Telemetry reporter for InfluxDB/Telegraf backend"
 
   def project do
@@ -27,7 +27,7 @@ defmodule InfluxTelemetryReporter.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:telemetry, "~> 1.1"},
+      {:telemetry, "~> 0.4 or ~> 1.0"},
       {:ex_doc, ">= 0.19.0", only: :dev},
       {:fluxter, "~> 0.10", only: :dev},
       {:telemetry_metrics, "~> 0.6", only: [:dev, :test]}


### PR DESCRIPTION
there is no change in 1.0 and only marked as stable version. However there are still some project still dependend on 0.4